### PR TITLE
Fix building on debian/kfreebsd

### DIFF
--- a/network-info.cabal
+++ b/network-info.cabal
@@ -40,11 +40,8 @@ Library
   build-depends:
     base == 4.*
 
-  if os(linux) || os(darwin)
-    c-sources: cbits/network-unix.c
+  if os(windows)
+    c-sources: cbits/network-windows.c
+    extra-libraries: iphlpapi
   else
-    if os(windows)
-      c-sources: cbits/network-windows.c
-      extra-libraries: iphlpapi
-    else
-      buildable: False
+    c-sources: cbits/network-unix.c

--- a/test/network-info-test.cabal
+++ b/test/network-info-test.cabal
@@ -14,11 +14,8 @@ Executable network-info-test
   build-depends:
     base == 4.*
 
-  if os(linux) || os(darwin)
-    c-sources: ../cbits/network-unix.c
+  if os(windows)
+    c-sources: ../cbits/network-windows.c
+    extra-libraries: iphlpapi
   else
-    if os(windows)
-      c-sources: ../cbits/network-windows.c
-      extra-libraries: iphlpapi
-    else
-      buildable: False
+    c-sources: ../cbits/network-unix.c


### PR DESCRIPTION
This fixes building on Debian/kFreeBSD and likely other unixes

Not sure if this is the Best way to fix this, but it it does build and the tests run OK.

```
Prelude> System.Info.os
"kfreebsdgnu"
```
