### PR TITLE
migrate to network/SockAddr and support for multiple addresses

### DIFF
--- a/cbits/common.h
+++ b/cbits/common.h
@@ -1,3 +1,7 @@
+#ifndef _COMMON_H
+#define _COMMON_H
+#include "string.h"
+
 inline void ipv4copy(struct sockaddr_in *dst, struct sockaddr *addr)
 {
     memcpy(dst, addr, sizeof(struct sockaddr_in));
@@ -24,3 +28,5 @@ inline void mbswszcopy(wchar_t *dst, const char *src, size_t dst_size)
     mbstowcs(dst, src, dst_size - 1);
     dst[dst_size - 1] = '\0';
 }
+
+#endif

--- a/cbits/list.c
+++ b/cbits/list.c
@@ -1,0 +1,37 @@
+#include "list.h"
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef OS_WINDOWS
+#include <ws2tcpip.h>
+#endif
+
+void prepend_address(struct addr_list **list, struct sockaddr *pl) {
+  struct sockaddr_storage *buf = malloc(sizeof(struct sockaddr_storage));
+  memset(buf,0 ,sizeof(struct sockaddr_storage));
+  if (pl->sa_family == AF_INET) {
+      memcpy(buf, pl, sizeof(struct sockaddr_in));
+  }
+  else if (pl->sa_family == AF_INET6) {
+    memcpy(buf, pl, sizeof(struct sockaddr_in6));
+  }
+  else {
+    return;
+  }
+  struct addr_list *head = malloc(sizeof(struct addr_list));
+  memset(head,0 ,sizeof(struct addr_list));
+  head->payload = buf;
+  head->next = *list;
+  *list = head;
+}
+
+void list_free(struct addr_list* head) {
+  struct addr_list *cur = head;
+  struct addr_list *tmp = NULL;
+  while (cur != NULL){
+    free(cur->payload);
+    tmp = cur;
+    cur = cur->next;
+    free(tmp);
+  }
+}

--- a/cbits/list.h
+++ b/cbits/list.h
@@ -1,0 +1,9 @@
+#ifndef _LIST_H
+#define _LIST_H
+#include "network.h"
+
+void prepend_address(struct addr_list **list,struct sockaddr *pl);
+void list_free(struct addr_list* head);
+void print_addrs(struct network_interface* iface);
+
+#endif

--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -22,6 +22,7 @@
 
 #include "network.h"
 #include "common.h"
+#include "list.h"
 
 
 void maccopy(unsigned char *dst, struct sockaddr *addr)
@@ -42,6 +43,7 @@ struct network_interface *add_interface(struct network_interface *ns, const wcha
     for (i = 0; i < max_ns; i++) {
         if (wcsempty(ns[i].name)) {
             wszcopy(ns[i].name, name, NAME_SIZE);
+            ns[i].addresses = NULL;
             return &ns[i];
         } else if (wcscmp(ns[i].name, name) == 0) {
             return &ns[i];
@@ -95,14 +97,13 @@ int c_get_network_interfaces(struct network_interface *ns, int max_ns)
         /* extract the address from this item */
         family = addr->sa_family;
         if (family == AF_INET) {
-            ipv4copy(&n->ip_address, addr);
+            prepend_address(&(n->addresses), addr);
         } else if (family == AF_INET6) {
-            ipv6copy(&n->ip6_address, addr);
+            prepend_address(&(n->addresses), addr);
         } else if (family == AF_PACKET) {
             maccopy(n->mac_address, addr);
         }
     }
-
     freeifaddrs(ifaddr);
     return count_interfaces(ns, max_ns);
 }

--- a/cbits/network-windows.c
+++ b/cbits/network-windows.c
@@ -9,6 +9,7 @@
 
 #include "network.h"
 #include "common.h"
+#include "list.h"
 
 
 int get_adapters_addresses(IP_ADAPTER_ADDRESSES *adapters, ULONG *size)
@@ -49,16 +50,13 @@ int c_get_network_interfaces(struct network_interface *ns, int max_ns)
             for (unicast = adapter->FirstUnicastAddress; unicast; unicast = unicast->Next) {
                 addr = unicast->Address.lpSockaddr;
                 family = addr->sa_family;
-
-                if (family == AF_INET) {
-                    ipv4copy(&ns[i].ip_address, addr);
-                } else if (family == AF_INET6) {
-                    ipv6copy(&ns[i].ip6_address, addr);
+                if (family == AF_INET || family == AF_INET6 ) {
+                    prepend_address(&(ns[i].addresses), addr);
                 }
-            }
 
             i++;
             adapter = adapter->Next;
+            }
         }
     }
 

--- a/cbits/network.h
+++ b/cbits/network.h
@@ -1,17 +1,30 @@
+#ifndef _NETWORK_h
+#define _NETWORK_h
+
 #ifdef OS_WINDOWS
 #include <winsock2.h>
 #else
 #include <netinet/in.h>
 #endif
 
+#include <wchar.h>
+
 #define NAME_SIZE (128+4)
 #define MAC_SIZE 6
 
+struct addr_list {
+    struct addr_list* next;
+    struct sockaddr_storage* payload;
+};
+
+
 struct network_interface {
     wchar_t name[NAME_SIZE];
-    struct sockaddr_in ip_address;
-    struct sockaddr_in6 ip6_address;
+    struct addr_list *addresses;
     unsigned char mac_address[MAC_SIZE];
 };
 
+
 int c_get_network_interfaces(struct network_interface *ns, int max_ns);
+
+#endif

--- a/network-info.cabal
+++ b/network-info.cabal
@@ -1,5 +1,5 @@
 name:           network-info
-version:        0.2.0.3
+version:        0.3.0.0
 synopsis:       Access the local computer's basic network configuration
 
 description:    This library provides simple read-only access to the
@@ -25,6 +25,7 @@ cabal-version:  >= 1.6
 extra-source-files:
   cbits/common.h,
   cbits/network.h,
+  cbits/list.h,
   test/src/Main.hs,
   test/network-info-test.cabal,
   test/run-tests.bat,
@@ -45,10 +46,10 @@ Library
   build-depends:
     base == 4.*
     , network >= 2.4
-
+  c-sources: cbits/list.c
   if os(windows)
     c-sources: cbits/network-windows.c
     extra-libraries: iphlpapi
-    cpp-options: -DOS_WINDOWS
+    cc-options: -DOS_WINDOWS
   else
     c-sources: cbits/network-unix.c

--- a/test/network-info-test.cabal
+++ b/test/network-info-test.cabal
@@ -4,18 +4,9 @@ build-type:     Simple
 cabal-version:  >= 1.6
 
 Executable network-info-test
-  hs-source-dirs: ../src src
-  include-dirs: ../cbits
   cc-options: -Wall -Werror
-
+  hs-source-dirs: src
   main-is: Main.hs
-  other-modules: Network.Info
-
   build-depends:
     base == 4.*
-
-  if os(windows)
-    c-sources: ../cbits/network-windows.c
-    extra-libraries: iphlpapi
-  else
-    c-sources: ../cbits/network-unix.c
+    , network-info

--- a/test/src/Main.hs
+++ b/test/src/Main.hs
@@ -8,6 +8,5 @@ main = do
 
 showInterface :: NetworkInterface -> String
 showInterface n = name n ++ "\n"
-               ++ "IPv4 Address: " ++ show (ipv4 n) ++ "\n"
-               ++ "IPv6 Address: " ++ show (ipv6 n) ++ "\n"
+               ++ "Addresses: " ++ show (addresses n) ++ "\n"
                ++ "MAC Address:  " ++ show (mac n) ++ "\n"


### PR DESCRIPTION
I needed ipv6 addresses to at least include the scope-id, so I replaced your custom structure with SockAddr from network. I also added support for multiple addresses per interface. 
The downside is that we now depend on network, but my guess is almost anybody who has to do something with network interfaces will want to use it anyway.
I tested the code on Linux and Windows. 
