### PR TITLE
don't redefine AF_PACKET on non-linux unices

### DIFF
--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -13,7 +13,9 @@
 #   include <sys/socket.h>
 #   include <net/if.h>
 #   include <net/if_dl.h>
-#   define AF_PACKET AF_LINK
+#   ifndef AF_PACKET
+#       define AF_PACKET AF_LINK
+#   endif
 #endif
 
 #ifdef __FreeBSD__


### PR DESCRIPTION
Turns into an error on OmniOS, for example (and probably other Solaris-derivatives).
