### PR TITLE
Add DragonflyBSD support.

### DIFF
--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -30,6 +30,10 @@
 #   include <net/pfvar.h>
 #endif
 
+#ifdef __DragonFly__
+#   include <net/pf/pfvar.h>
+#endif
+
 #include "network.h"
 #include "common.h"
 


### PR DESCRIPTION
I just copied this out of the dragonfly hs-network-info package,
which credits "haskell@freebsd.org".