### PR TITLE
Depending in PF potentially breaks FreeBSD build.

### DIFF
--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef __DragonFly__
-#   include <net/pf/pfvar.h>
+#   include <netinet/in.h>
 #endif
 
 #include "network.h"

--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -29,7 +29,7 @@
 #endif
 
 #ifdef __FreeBSD__
-#   include <net/pfvar.h>
+#   include <netinet/in.h>
 #endif
 
 #ifdef __DragonFly__


### PR DESCRIPTION
Not all FreeBSD systems do have PF as a packet filter installed. Depending on `net/pf/pfvar.h` breaks the build on these systems.