### PR TITLE
Fix segmentation fault for more than 64 interfaces

### DIFF
--- a/cbits/network-unix.c
+++ b/cbits/network-unix.c
@@ -132,6 +132,9 @@ int c_get_network_interfaces(struct network_interface *ns, int max_ns)
         /* lookup or add a new interface with the given name */
         n = add_interface(ns, name, max_ns);
 
+        if (n == NULL)
+            break;
+
         /* extract the address from this item */
         family = addr->sa_family;
         if (family == AF_INET) {


### PR DESCRIPTION
`getifaddrs` can return a linked list of more than `max_ns`
interfaces, and when that happens `add_interface` will begin to
return `NULL` when the `ns` array is full.

This fixes that by breaking from the loop when `add_interface` fails,
truncating the results to `max_ns` entries.